### PR TITLE
TestFX tests execution profiles for headless and non-headless modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,35 @@ To run Komet with JPro in a Docker container, follow these steps:
 
 **Note:** Komet requires sample data to function fully.
 
+## Running Komet GUI Tests Using the TestFX Framework
+The Komet application includes GUI tests built with the TestFX framework. By default, these tests run in headless mode, 
+which is ideal for continuous integration (CI) environments or situations where graphical interaction is unnecessary.
+1. **Running TestFX Tests in Headless Mode (Default)**<br>
+   To execute all unit tests, including the TestFX GUI tests, in headless mode (without launching a GUI window), run:
+   ```bash
+   mvn test
+   ```
+2. **Running TestFX Tests in Graphical Mode (Non-Headless)**<br>
+   If you need to observe the GUI during testing—for instance, when debugging UI components—you can disable 
+   headless mode by setting the headless property to false.<br>
+   To run all tests in non-headless mode:
+   ```bash
+   mvn test -Dheadless=false
+   ```
+3. **Running Specific Tests**<br>
+   To run a specific test class in a specific module, for example the `LoginTest` class in the `kview` module:
+   ```bash
+   mvn test -pl kview -Dtest=LoginTest -Dheadless=false
+   ```
+   To run a specific test method inside a specific class, for example the `testSuccessfulAuthentication` method in the
+   `LoginTest` class in the `kview` module:
+     ```bash
+    mvn test -pl kview -Dtest=LoginTest#testSuccessfulAuthentication -Dheadless=false
+     ```
+**Important Note on Test Execution**<br>
+The tests will only run once after they pass successfully. To trigger the tests again, changes must be made 
+to any part of the project.
+
 ## Issues and Contributions
 Technical and non-technical issues can be reported to the [Issue Tracker](https://github.com/ikmdev/komet/issues).
 

--- a/kview/pom.xml
+++ b/kview/pom.xml
@@ -89,40 +89,74 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>
-                        -Dtestfx.headless=true
-                        -Dprism.order=sw
-                        -Dprism.text=t2k
-                        -Djava.awt.headless=true
-                        --add-opens=javafx.graphics/com.sun.glass.ui=org.testfx.core
-                        --add-opens=javafx.graphics/com.sun.javafx.application=org.testfx.core
-                        --add-exports=javafx.graphics/com.sun.javafx.application=org.testfx.core
-                        --add-exports=javafx.graphics/com.sun.glass.ui=org.testfx.monocle
-                        --add-exports=javafx.graphics/com.sun.javafx.util=org.testfx.monocle
-                        --add-exports=javafx.base/com.sun.javafx.logging=org.testfx.monocle
-                    </argLine>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>default-test</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
+
+    <!--TestFX configuration for headless and graphical tests-->
+    <properties>
+        <commonArgs>
+            --add-opens=javafx.graphics/com.sun.glass.ui=org.testfx.core
+            --add-opens=javafx.graphics/com.sun.javafx.application=org.testfx.core
+            --add-exports=javafx.graphics/com.sun.javafx.application=org.testfx.core
+            --add-exports=javafx.graphics/com.sun.glass.ui=org.testfx.monocle
+            --add-exports=javafx.graphics/com.sun.javafx.util=org.testfx.monocle
+            --add-exports=javafx.base/com.sun.javafx.logging=org.testfx.monocle
+        </commonArgs>
+    </properties>
+    <profiles>
+        <profile>
+            <id>headless-tests</id>
+            <activation>
+                <property>
+                    <name>headless</name>
+                    <value>true</value>
+                </property>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-<!--                            <useModulePath>true</useModulePath>-->
+                            <argLine>
+                                -Dtestfx.headless=true
+                                -Dprism.order=sw
+                                -Dprism.text=t2k
+                                -Djava.awt.headless=true
+                                ${commonArgs}
+                            </argLine>
+                            <useModulePath>false</useModulePath> <!--When some JPMS issues are resolved, this can be set to true-->
                             <forkCount>1</forkCount>
                             <reuseForks>false</reuseForks>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>graphical-tests</id>
+            <activation>
+                <property>
+                    <name>headless</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>
+                                -Dtestfx.headless=false
+                                ${commonArgs}
+                            </argLine>
+                            <useModulePath>false</useModulePath> <!--When some JPMS issues are resolved, this can be set to true-->
+                            <forkCount>1</forkCount>
+                            <reuseForks>false</reuseForks>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
This PR introduces execution profiles for TestFX tests, enabling both headless and non-headless modes. It serves as a follow-up to the [PR](https://github.com/Sandec/komet-jpro/pull/1) titled “[JPRO-25] Build POC for Automated Testing using TestFX Framework,” further enhancing our automated testing capabilities by allowing flexibility in how tests are run.