### PR TITLE
[JPRO-52] Disable User Login for Desktop

### DIFF
--- a/application/src/main/java/dev/ikm/komet/app/LoginFeatureFlag.java
+++ b/application/src/main/java/dev/ikm/komet/app/LoginFeatureFlag.java
@@ -1,0 +1,27 @@
+package dev.ikm.komet.app;
+
+/**
+ * Enum representing the different states of the login feature in the application.
+ */
+public enum LoginFeatureFlag {
+
+    /**
+     * Login is enabled only on web platforms.
+     */
+    ENABLED_WEB_ONLY,
+
+    /**
+     * Login is enabled only on desktop platforms.
+     */
+    ENABLED_DESKTOP_ONLY,
+
+    /**
+     * Login is enabled on both desktop and web platforms.
+     */
+    ENABLED,
+
+    /**
+     * Login feature is disabled on all platforms.
+     */
+    DISABLED
+}

--- a/application/src/main/java/dev/ikm/komet/app/WebApp.java
+++ b/application/src/main/java/dev/ikm/komet/app/WebApp.java
@@ -338,8 +338,14 @@ public class WebApp extends Application {
             scene.getStylesheets().addAll(CssHelper.defaultStyleSheet());
             stage.setScene(scene);
 
-            state.set(LOGIN);
-            launchLoginPage(stage);
+            if (IS_BROWSER) {
+                state.set(LOGIN);
+                launchLoginPage(stage);
+            } else {
+                state.set(SELECT_DATA_SOURCE);
+                state.addListener(this::appStateChangeListener);
+                launchSelectDataSourcePage(stage);
+            }
 
             addEventFilters(stage);
 
@@ -831,7 +837,14 @@ public class WebApp extends Application {
                     Platform.runLater(() -> state.set(LOADING_DATA_SOURCE));
                     TinkExecutor.threadPool().submit(new LoadDataSourceTask(state));
                 }
-                case RUNNING -> launchLandingPage(primaryStage, userProperty.get());
+                case RUNNING -> {
+                    if (userProperty.get() == null) {
+                        String username = System.getProperty("user.name");
+                        String capitalizeUsername = username.substring(0, 1).toUpperCase() + username.substring(1);
+                        userProperty.set(new User(capitalizeUsername));
+                    }
+                    launchLandingPage(primaryStage, userProperty.get());
+                }
                 case SHUTDOWN -> quit();
             }
         } catch (Throwable e) {

--- a/application/src/main/java/dev/ikm/komet/app/WebApp.java
+++ b/application/src/main/java/dev/ikm/komet/app/WebApp.java
@@ -112,6 +112,7 @@ import java.util.function.Consumer;
 import java.util.prefs.BackingStoreException;
 
 import static dev.ikm.komet.app.AppState.*;
+import static dev.ikm.komet.app.LoginFeatureFlag.*;
 import static dev.ikm.komet.framework.KometNodeFactory.KOMET_NODES;
 import static dev.ikm.komet.framework.window.WindowSettings.Keys.*;
 import static dev.ikm.komet.kview.events.EventTopics.JOURNAL_TOPIC;
@@ -338,14 +339,7 @@ public class WebApp extends Application {
             scene.getStylesheets().addAll(CssHelper.defaultStyleSheet());
             stage.setScene(scene);
 
-            if (IS_BROWSER) {
-                state.set(LOGIN);
-                launchLoginPage(stage);
-            } else {
-                state.set(SELECT_DATA_SOURCE);
-                state.addListener(this::appStateChangeListener);
-                launchSelectDataSourcePage(stage);
-            }
+            handleLoginFeature(ENABLED_WEB_ONLY, stage);
 
             addEventFilters(stage);
 
@@ -358,6 +352,57 @@ public class WebApp extends Application {
             LOG.error("Failed to initialize the application", ex);
             Platform.exit();
         }
+    }
+
+    /**
+     * Handles the login feature based on the provided {@link LoginFeatureFlag} and platform.
+     *
+     * @param loginFeatureFlag the current state of the login feature
+     * @param stage            the current application stage
+     */
+    public void handleLoginFeature(LoginFeatureFlag loginFeatureFlag, Stage stage) {
+        switch (loginFeatureFlag) {
+            case ENABLED_WEB_ONLY -> {
+                if (IS_BROWSER) {
+                    startLogin(stage);
+                } else {
+                    startSelectDataSource(stage);
+                }
+            }
+            case ENABLED_DESKTOP_ONLY -> {
+                if (IS_DESKTOP) {
+                    startLogin(stage);
+                } else {
+                    startSelectDataSource(stage);
+                }
+            }
+            case ENABLED -> startLogin(stage);
+            case DISABLED -> startSelectDataSource(stage);
+        }
+    }
+
+    /**
+     * Initiates the login process by setting the application state to {@link AppState#LOGIN}
+     * and launching the login page.
+     *
+     * @param stage the current application stage
+     */
+    private void startLogin(Stage stage) {
+        state.set(LOGIN);
+        launchLoginPage(stage);
+    }
+
+    /**
+     * Initiates the data source selection process by setting the application state
+     * to {@link AppState#SELECT_DATA_SOURCE}, adding a state change listener, and launching
+     * the data source selection page.
+     *
+     * @param stage the current application stage
+     */
+    private void startSelectDataSource(Stage stage) {
+        state.set(SELECT_DATA_SOURCE);
+        state.addListener(this::appStateChangeListener);
+        launchSelectDataSourcePage(stage);
     }
 
     @Override


### PR DESCRIPTION
As a User, I want to be able to load the Komet desktop app and view the landing page without having to log in.

Acceptance Criteria:

- On web, user shall see the landing page only if they log in.
- On desktop, user shall see the landing page without having to log in.
- If applicable, implement feature flagging so that user login can be easily enabled/disabled for both platforms.
- Provide documentation on how feature flagging was implemented.